### PR TITLE
Add configuration for building app in docker container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 DEPLOYED_APP_URL=
+
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=postgres
+
+APP_PORT=8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use the official Gradle image with JDK 17 as the base image
+FROM gradle:7.6.1-jdk17 AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy the project to the working directory
+COPY . .
+
+# Run Gradle build with no unnecessary demons and test execution
+RUN gradle clean build --no-daemon -x test
+
+# Use the official OpenJDK image with JDK 17 as the runtime base image
+FROM openjdk:17
+
+# Set the working directory in the runtime container
+WORKDIR /app
+
+# Copy the compiled JAR & .properties file from the build stage to the runtime stage
+COPY --from=build /app/build/libs/*.jar app.jar
+
+# Set the entrypoint for the runtime container
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,19 @@ services:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_PASSWORD}
+
+  jira-addon-api:
+    env_file: ./.env
+    container_name: jira-addon-api
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - ${APP_PORT}:${APP_PORT}
+    depends_on:
+      - jira-addon-db
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://jira-addon-db:${DB_PORT}/${POSTGRES_NAME}
+      - SPRING_DATASOURCE_USERNAME=${DB_USER}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
+      - SERVER_PORT=${APP_PORT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,14 @@
-DB_SCHEMA_NAME: jira_addon_db
-
 spring:
   config.import: optional:file:.env[.properties]
   jpa.hibernate.ddl-auto: none
 
   datasource:
-    url: jdbc:postgresql://localhost:${DB_PORT}/${DB_NAME}?currentSchema=${DB_SCHEMA_NAME}
+    url: jdbc:postgresql://localhost:${DB_PORT}/${DB_NAME}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   liquibase:
-    default-schema: ${DB_SCHEMA_NAME}
-    # change-log: classpath:/db/changelog/db.changelog-master.yaml
     enabled: true
 
 addon:


### PR DESCRIPTION
Added configuration that allows to build the application in a docker container using the `docker compose up` command. Also, removed the need in creating the schema jira_addon_db inside the DB launched in a container. Now all necessary tables are created in public schema as by default, that should be enough for a local for plugin DB